### PR TITLE
fix(release): initial_tag en cliff.toml

### DIFF
--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Compute next version
         id: version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEXT=$(git cliff --bumped-version)
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
@@ -47,6 +49,8 @@ jobs:
         run: git checkout -b release/${{ steps.version.outputs.version }}
 
       - name: Generate changelog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ -f CHANGELOG.md ]; then
             git cliff --tag ${{ steps.version.outputs.next }} --prepend CHANGELOG.md --unreleased

--- a/cliff.toml
+++ b/cliff.toml
@@ -48,3 +48,9 @@ commit_parsers = [
   { message = "^build", skip = true },
   { message = "^style\\(automatic\\)", skip = true },
 ]
+
+[bump]
+# Sin esto, `git cliff --bumped-version` calcula la primera versión sin el
+# prefijo "v" (ej. "0.1.0"), lo que no matchea `tag_pattern` de arriba y
+# hace fallar el workflow Cut Release apenas no hay tags todavía en el repo.
+initial_tag = "v0.1.0"


### PR DESCRIPTION
Mismo fix que en Crono/HireFire/Portfolio: sin [bump] initial_tag, git cliff --bumped-version puede calcular la primera versión sin el prefijo v cuando no hay tags, lo que no matchea tag_pattern = "v[0-9]*" y hace fallar Cut Release. Ya aplicado en develop.